### PR TITLE
increase mem request/limits

### DIFF
--- a/kubernetes/EncryptedResource/resource.yaml
+++ b/kubernetes/EncryptedResource/resource.yaml
@@ -38,10 +38,10 @@ items:
             - image: "quay.io/razee/encryptedresource:{{{TRAVIS_TAG}}}"
               resources:
                 limits:
-                  memory: 200Mi
+                  memory: 500Mi
                   cpu: 100m
                 requests:
-                  memory: 75Mi
+                  memory: 200Mi
                   cpu: 40m
               env:
                 - name: USER_AGENT_NAME


### PR DESCRIPTION
We've noticed a lot of CrashLoopBackOffs occurring in this microservice that seemed to be remedied by upping mem req/lim. The numbers chosen were arbitrary.